### PR TITLE
Fix expected YAML to be YAML1.1-aware

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,9 @@ def make_git_repo_and_return_date(git_dir)
 end
 
 def deploy_info_yaml_from_git_template(git_commit)
+  # YAML1.1 is one of those things... :')
+  git_commit = "'#{git_commit}'" if /\A0[0-7]*[89]/.match?(git_commit)
+
   <<~CONTENT
     ---
     deploy_ref: main


### PR DESCRIPTION
Psych renders strings leading with 0[0-9] with quotes and it generates flaky results.