### PR TITLE
Introducing `Scc::Instrumentable` + Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           ruby-version: 3.2.2
           bundler-cache: true
       - name: Rspec
-        run: bin/rspec --format documentation
+        run: make tests
       - name: Code Coverage Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
@@ -50,7 +50,7 @@ jobs:
           ruby-version: 3.2.2
           bundler-cache: true
       - name: Breakman
-        run: bin/brakeman --run-all-checks --force --no-exit-on-warn --quiet --no-pager --no-color
+        run: make static-analysis
 
   standardrb:
     runs-on: ubuntu-latest
@@ -63,5 +63,4 @@ jobs:
           ruby-version: 3.2.2
           bundler-cache: true
       - name: StandardRB
-        run: bin/standardrb --no-fix -f github
-
+        run: make lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.1] - 2024-05-01
+
+- Add a thin layer on top of `ActiveSupport::Instrumentation`
+
 ## [0.1.0] - 2024-01-31
 
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
+gem "activesupport", "~> 7"
 
 group :development, :test do
   gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,36 @@
 PATH
   remote: .
   specs:
-    scc-foundation (0.1.0)
+    scc-foundation (0.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.7)
     brakeman (6.1.1)
       racc
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.2.1)
+    i18n (1.14.4)
+      concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.11.1)
       rdoc
@@ -21,6 +38,8 @@ GEM
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    minitest (5.22.3)
+    mutex_m (0.2.0)
     parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -88,12 +107,15 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.1)
     stringio (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport (~> 7)
   brakeman
   debug
   rake (~> 13.0)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+tests:
+	bin/rspec --format documentation
+
+lint-autofix:
+	bin/standardrb --fix-unsafely
+
+lint:
+	bin/standardrb --no-fix -f github
+
+static-analysis:
+	bin/brakeman --run-all-checks --force --no-exit-on-warn --quiet --no-pager --no-color

--- a/lib/scc/instrumentable.rb
+++ b/lib/scc/instrumentable.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "active_support/notifications"
+require "active_support/core_ext/string/inflections"
+
+##
+# Provides a thin instrumentation layer on top of ActiveSupport::Notifications
+#
+# Autodetect's the namespace of the event based on the consumer class.
+module Scc
+  module Instrumentable
+    ##
+    # Instrument an operation.
+    #
+    # Hooks into +ActiveSupport::Notifications+ an event.
+    #
+    # @param event [String] Name of the event
+    # @param payload [Hash, nil] Payload for the event.
+    #   It is recommended that the payload contains as Plain Old Ruby Objects.
+    # @param block [Proc] Actual operation to be performed
+    #   +block+ may not be set.
+    # @example Instrumenting an operation
+    #   # in your class:
+    #   include Scc:Instrumentable
+    #   # ...
+    #   def my_method
+    #     instrument('my_method') { 2+2 }
+    #   end
+    #
+    # @example Instrumenting an operation with arguments
+    #   # in your class:
+    #   include Scc:Instrumentable
+    #   # ...
+    #   def my_method
+    #     instrument('my_method', { extra: :data }) { 2+2 }
+    #   end
+    #
+    # @example Instrumenting an operation without a block
+    #   # in your class:
+    #   include Scc:Instrumentable
+    #   # ...
+    #   def my_method
+    #     instrument('my_method', { extra: :data })
+    #   end
+
+    def instrument(event, payload = nil, &block)
+      namespace = instrumentation_namespace
+      ActiveSupport::Notifications.instrument("#{event}.#{namespace}", payload) do
+        block&.call
+      end
+    end
+
+    ##
+    # Instrumentation Namespace
+    #
+    # The namespace for +ActiveSupport::Notifications+ to report the current
+    # event.
+    #
+    # @returns [String] the instrumentation namespace
+    def instrumentation_namespace
+      @instrumentation_namespace ||= default_instrumentation_namespace
+    end
+
+    protected
+
+    def default_instrumentation_namespace
+      self.class.name.split("::").map(&:underscore).reverse.join(".")
+    end
+  end
+end

--- a/lib/scc/version.rb
+++ b/lib/scc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scc
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lib/scc/instrumentable_spec.rb
+++ b/spec/lib/scc/instrumentable_spec.rb
@@ -1,0 +1,77 @@
+require "scc/instrumentable"
+
+# Making things testable sometimes suck...
+class TopLevelClassSubject
+end
+
+module FirstMod
+  class SecondClass
+    class ThirdClass
+    end
+  end
+end
+# / Making things testable sometimes suck...
+
+RSpec.describe Scc::Instrumentable do
+  describe "#instrumentation_namespace" do
+    context "when class is not namespaced" do
+      subject do
+        TopLevelClassSubject.include(described_class).new
+      end
+
+      it "returns the class name in lowercase" do
+        expect(subject.instrumentation_namespace).not_to match(/[A-Z]/)
+      end
+
+      it "snake-cases the name" do
+        expect(subject.instrumentation_namespace).to eq("top_level_class_subject")
+      end
+    end
+
+    context "when class is namespaced" do
+      subject do
+        FirstMod::SecondClass::ThirdClass.include(described_class).new
+      end
+
+      it "returns the class name in camelcase" do
+        expect(subject.instrumentation_namespace).not_to match(/[A-Z]/)
+      end
+
+      it "includes the fully qualified class name in snake-cases", :aggregate_failures do
+        expect(subject.instrumentation_namespace).to include("first_mod")
+        expect(subject.instrumentation_namespace).to include("second_class")
+        expect(subject.instrumentation_namespace).to include("third_class")
+      end
+
+      it "returns the name in reverse DNS notation: inner.middle.toplevel", :aggregate_failures do
+        expect(subject.instrumentation_namespace).to eq("third_class.second_class.first_mod")
+      end
+    end
+  end
+
+  describe "#instrument" do
+    subject do
+      TopLevelClassSubject.include(described_class).new
+    end
+
+    it "calls ActiveSupport with a namespaced event" do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      subject.instrument("event") { 2 + 2 }
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument)
+        .once
+        .with("event.top_level_class_subject", nil)
+    end
+
+    it "forwards the payload to ActiveSupport" do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      subject.instrument("event", {data: :extra}) { 2 + 2 }
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument)
+        .once
+        .with("event.top_level_class_subject", {data: :extra})
+    end
+  end
+end


### PR DESCRIPTION
`Scc::Instrumentable` is a thin module layer on top of `ActiveRecord::Notifications`.

It provides an `instrument` method that will derive automatically the event namespace from it's class name.

Additional goodie: A `Makefile` with the CI tasks