### PR TITLE
Expose the instrumentation namespace to consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.1.2] - 2024-05-02
+
+- Allow classes consuming `Scc::Instrumentable` to expose the namespace where
+  they report.
+
 ## [0.1.1] - 2024-05-01
 
 - Add a thin layer on top of `ActiveSupport::Instrumentation`

--- a/lib/scc/instrumentable.rb
+++ b/lib/scc/instrumentable.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/concern"
 require "active_support/notifications"
 require "active_support/core_ext/string/inflections"
 
@@ -9,6 +10,7 @@ require "active_support/core_ext/string/inflections"
 # Autodetect's the namespace of the event based on the consumer class.
 module Scc
   module Instrumentable
+    extend ActiveSupport::Concern
     ##
     # Instrument an operation.
     #
@@ -56,13 +58,19 @@ module Scc
     #
     # @returns [String] the instrumentation namespace
     def instrumentation_namespace
-      @instrumentation_namespace ||= default_instrumentation_namespace
+      @instrumentation_namespace ||= self.class.instrumentation_namespace
     end
 
-    protected
+    module ClassMethods
+      def instrumentation_namespace
+        default_instrumentation_namespace
+      end
 
-    def default_instrumentation_namespace
-      self.class.name.split("::").map(&:underscore).reverse.join(".")
+      protected
+
+      def default_instrumentation_namespace
+        name.split("::").map(&:underscore).reverse.join(".")
+      end
     end
   end
 end

--- a/spec/lib/scc/instrumentable_spec.rb
+++ b/spec/lib/scc/instrumentable_spec.rb
@@ -13,10 +13,10 @@ end
 # / Making things testable sometimes suck...
 
 RSpec.describe Scc::Instrumentable do
-  describe "#instrumentation_namespace" do
+  describe ".instrumentation_namespace" do
     context "when class is not namespaced" do
       subject do
-        TopLevelClassSubject.include(described_class).new
+        TopLevelClassSubject.include(described_class)
       end
 
       it "returns the class name in lowercase" do
@@ -30,7 +30,7 @@ RSpec.describe Scc::Instrumentable do
 
     context "when class is namespaced" do
       subject do
-        FirstMod::SecondClass::ThirdClass.include(described_class).new
+        FirstMod::SecondClass::ThirdClass.include(described_class)
       end
 
       it "returns the class name in camelcase" do


### PR DESCRIPTION
- Expose the instrumentation namespace via Class Method to be used on subscribers.

```ruby
attach_to InstrumentableClass.instrumentation_namespace
```